### PR TITLE
Store selected property and selected visualisation in URL.

### DIFF
--- a/static/visualisation/js/URIHash.js
+++ b/static/visualisation/js/URIHash.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2018 by Jakob Rieck.
+ * Inspired and based on work by David Kerkeslager
+ * see https://stackoverflow.com/a/1264046
+ */
+export let URIHash =
+{
+    /**
+     * Load the contents of the URI hash into an object, where the key maps to the provided
+     * value.
+     */
+    load : function()
+    {
+        // Split initial '#' symbols
+        return document.location.hash.substring(1)
+            // Separate individual items
+            .split('&')
+            // Separate keys and values
+            .map(str => str.split('='))
+            // Only process expected keys and values
+            .filter(tuple => tuple.length == 2)
+            // Build up object mapping keys to values
+            .reduce(function(r, pair) {
+                let key = pair[0], value = pair[1];
+
+                r[decodeURI(key)] = decodeURI(value);
+                return r;
+            }, {});
+    },
+
+    /**
+     * Takes an object to serialize and stores it in the URI hash.
+     */
+    store : function(obj)
+    {
+        let hash = Object.keys(obj)
+                         // Encode key-value pair as string with = separator
+                         .map(k => encodeURI(k) + '=' + encodeURI(obj[k]))
+                         .join('&')
+
+        document.location.hash = hash
+    },
+
+    /**
+     * Get the value of a key from the hash.  If the hash does not contain the key or the hash is invalid,
+     * the function returns undefined.
+     */
+    get: function(key)
+    {
+        return this.load()[key];
+    },
+
+    /**
+     * Set the value of a key in the hash.  If the key does not exist, the key/value pair is added.
+     */
+    set: function(key, value)
+    {
+        var dump = this.load();
+        dump[key] = value;
+        this.store(dump)
+    }
+}

--- a/static/visualisation/visualisation.html
+++ b/static/visualisation/visualisation.html
@@ -15,7 +15,7 @@
         type="text/javascript"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
         <link href="css/bootstrap.css" rel="stylesheet" />
-        <script src="js/Vofpffs.js"></script>
+        <script type="module" src="js/Vofpffs.js"></script>
         <link href="css/Vofpffs.css" rel="stylesheet" />
 
         <div class="grid-container" onload="renderChart()">
@@ -24,8 +24,8 @@
 <!--                     <p id="selectedDbSetParagraph">Selected Set: A</p>
  -->
                     <div>
-                        <select id="visualSelector" class="custom-select" onchange="onVisualChange(this.value)"></select>
-                        <select id="propertySelector" class="custom-select" onchange="onPropertyChange(this.value)" style="display: none"></select>
+                        <select id="visualSelector" class="custom-select"></select>
+                        <select id="propertySelector" class="custom-select" style="display: none"></select>
                     </div>
 
                     <p id="idParagraph">Key :</p>
@@ -51,6 +51,6 @@
         </div>
     </div>
 
-    <script src="js/Vofpffs.js"></script>
+    <script type="module" src="js/Vofpffs.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The proposed change uses the URL fragment introduced by the '#' symbol (the hash) to store application specific settings. This place is used because modifying the query string of the URL would cause an unwanted reload.

For now, the selected property and the selected visualisation is saved, once it is changed from the default setting.

Addresses #7 